### PR TITLE
Show child leaves in usage output

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,8 @@
 {
   "cSpell.words": [
     "redent",
-    "subcommand"
+    "subcommand",
+    "subcommands"
   ],
   "tslint.enable": true
 }

--- a/src/get-path-and-description-of-leaves.ts
+++ b/src/get-path-and-description-of-leaves.ts
@@ -1,0 +1,31 @@
+import { Command } from './types';
+import { LEAF } from './constants';
+
+type PathAndDescription = {
+  path: string[];
+  description?: string;
+};
+
+export function getPathAndDescriptionOfLeaves(
+  command: Command,
+  path: string[],
+): PathAndDescription[] {
+  if (command.hidden) {
+    return [];
+  }
+  if (command._type === LEAF) {
+    return [
+      {
+        path,
+        description: command.description,
+      },
+    ];
+  }
+  const returnValue: PathAndDescription[] = [];
+  for (const subcommand of command.subcommands) {
+    returnValue.push(
+      ...getPathAndDescriptionOfLeaves(subcommand, [...path, subcommand.name]),
+    );
+  }
+  return returnValue;
+}

--- a/src/get-usage.ts
+++ b/src/get-usage.ts
@@ -4,6 +4,7 @@ import { Command } from './types';
 import { BRANCH, LEAF, RED_ERROR } from './constants';
 import { createTextList } from './create-text-list';
 import { regularizeText, wrapInSquareBrackets } from './util';
+import { getPathAndDescriptionOfLeaves } from './get-path-and-description-of-leaves';
 
 const INDENT_SIZE = 3;
 
@@ -18,12 +19,10 @@ export function getUsage(commands: Command[], errorMessage?: string) {
     case BRANCH:
       firstParagraph += ' <subcommand> ...';
       otherParagraphs.push('Subcommands:');
-      const filteredSubcommands = command.subcommands.filter(
-        subcommand => !subcommand.hidden,
-      );
-      const items: Parameters<typeof createTextList> = filteredSubcommands.map(
-        ({ name, description }) => ({
-          name,
+      const nameAndDescriptionOfLeaves = getPathAndDescriptionOfLeaves(command, []);
+      const items: Parameters<typeof createTextList> = nameAndDescriptionOfLeaves.map(
+        ({ path, description }) => ({
+          name: path.join(' '),
           text: description,
         }),
       );


### PR DESCRIPTION
Previously the "usage" output for a command branch would list the names and descriptions of the command's immediate subcommand children. For example, the top-level usage for `aai` would show the descriptions for `app`, `user`, and `get-starter-apps`. Once this PR is merged we will instead show the descriptions and paths for all the LEAVES for the current command. As an example, here is how the usage for the alwaysAI CLI will look:

```
$ aai
Usage: aai <subcommand> ...

   Manage your alwaysAI assets and environment

Subcommands:

   app configure     : Configure this directory as an alwaysAI application
   app deploy        : Deploy this application to a target device
   app install       : Install this application's dependencies
   app exec          : Run a command in the target directory
   app models add    : Add model(s) to this application
   app models remove : Remove model(s) from this application
   app models search : Search models in the alwaysAI Cloud
   app models show   : Show this application's "models" configuration
   app models update : Update this application's models to the latest versions
   app shell         : Launch a bash shell in the target directory
   app show          : Show the application configuration of your current directory
   app start         : Run this application's "start" script
   user login        : Log in to the alwaysAI Cloud
   user logout       : Log out of the alwaysAI Cloud
   user show         : Show the currently logged in user
   get-starter-apps  : Download the alwaysAI starter applications

$ aai app
Usage: aai app <subcommand> ...

   Develop an alwaysAI application

Subcommands:

   configure     : Configure this directory as an alwaysAI application
   deploy        : Deploy this application to a target device
   install       : Install this application's dependencies
   exec          : Run a command in the target directory
   models add    : Add model(s) to this application
   models remove : Remove model(s) from this application
   models search : Search models in the alwaysAI Cloud
   models show   : Show this application's "models" configuration
   models update : Update this application's models to the latest versions
   shell         : Launch a bash shell in the target directory
   show          : Show the application configuration of your current directory
   start         : Run this application's "start" script
```