### PR TITLE
Simplify logic using linked lists and recursion

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,7 @@
 {
   "cSpell.words": [
+    "alwaysai",
+    "alwayscli",
     "argvs",
     "carnesen",
     "redent",

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ A framework for building command-line interfaces (CLIs) in Node.js. This package
 npm install @alwaysai/alwayscli
 ```
 
-In an `alwaysCLI` CLI, commands are organized into a tree. Each "leaf" represents an action whereas "branches" collect and organize leaves. For example, in the command `alwaysai user logIn`, `alwaysai` is the "root" command, `user` is a branch of commands related to user authentication and `logIn` is the specific action (leaf command). Your CLI need not have branches. Here is a simple CLI that has a leaf as its root:
+In an `alwaysCLI` program, commands are organized into a tree. Each "leaf" represents an action whereas "branches" collect and organize leaves. For example, in the command `alwaysai user login`, `alwaysai` is the "root" command, `user` is a branch of commands related to user authentication and `login` is the action. Your CLI need not have branches. Here is a simple CLI that has a leaf as its root:
 ```ts
 import {
   createCli,

--- a/src/__snapshots__/get-usage.test.ts.snap
+++ b/src/__snapshots__/get-usage.test.ts.snap
@@ -15,3 +15,11 @@ Options:
 
    [--message <str>] : A message"
 `;
+
+exports[`getUsage Creates a usage string for a leaf without a parent branch 1`] = `
+"Usage: echo [<options>]
+
+Options:
+
+   [--message <str>] : A message"
+`;

--- a/src/accumulate-command-stack.test.ts
+++ b/src/accumulate-command-stack.test.ts
@@ -1,8 +1,6 @@
 import { accumulateCommandStack } from './accumulate-command-stack';
 import { createBranch } from './create-branch';
 import { createLeaf } from './create-leaf';
-import { runAndCatch } from '@carnesen/run-and-catch';
-import { Command } from './types';
 
 const leaf = createLeaf({
   name: 'echo',
@@ -17,32 +15,15 @@ const root = createBranch({
 });
 
 describe(accumulateCommandStack.name, () => {
-  it('accumulates commands into commandStack based on passed maybe command names', () => {
-    const {
-      commandStack,
-      badCommandName: badCommand,
-      argsArgv: positionalArgs,
-    } = accumulateCommandStack(root, ['echo', 'foo']);
-    expect(commandStack.branches[0]).toBe(root);
-    expect(commandStack.leaf).toBe(leaf);
-    expect(badCommand).toBe(undefined);
-    expect(positionalArgs).toEqual(['foo']);
+  it('accumulates command linked list', () => {
+    const remainingArgv = accumulateCommandStack(root, ['echo', 'foo']);
+    expect(root.next && root.next.name).toBe('echo');
+    expect(remainingArgv).toEqual(['foo']);
   });
 
-  it('returns badCommand if bad command name is provided', () => {
-    const { commandStack, badCommandName: badCommand } = accumulateCommandStack(root, [
-      'eco',
-    ]);
-    expect(badCommand).toEqual('eco');
-    expect(commandStack.branches).toEqual([root]);
-  });
-
-  it('throws "unexpected command type" if passed an unexpected command type', async () => {
-    const badRoot = { ...root, _type: 'bogus' };
-    const ex = await runAndCatch(accumulateCommandStack, badRoot as Command, [
-      'echo',
-      'foo',
-    ]);
-    expect(ex.message).toMatch(/unexpected command type/i);
+  it('does not attach a "next" command if the name does not match', () => {
+    const remainingArgv = accumulateCommandStack(root, ['bad-command-name']);
+    expect(root.next).toBe(undefined);
+    expect(remainingArgv).toEqual(['bad-command-name']);
   });
 });

--- a/src/create-argv-interface.ts
+++ b/src/create-argv-interface.ts
@@ -1,0 +1,90 @@
+import { Leaf, Branch } from './types';
+import { accumulateCommandStack } from './accumulate-command-stack';
+import { accumulateArgvObject } from './accumulate-argv-object';
+import { accumulateOptionsValues } from './accumulate-options-values';
+
+import { UsageError } from './usage-error';
+import { TerseError } from './terse-error';
+import { BRANCH } from './constants';
+import { findVersion } from './find-version';
+import { callGetValue } from './call-get-value';
+import { LastCommand } from './last-command';
+
+export function createArgvInterface(rootCommand: Branch | Leaf<any, any, any>) {
+  return async function argvInterface(...argv: string[]) {
+    if (['-v', '--version'].includes(argv[0])) {
+      if (rootCommand.version) {
+        return rootCommand.version;
+      }
+      const foundVersion = await findVersion();
+      if (foundVersion) {
+        return foundVersion;
+      }
+      throw new TerseError('Failed to find a CLI version string');
+    }
+    const {
+      foundHelp,
+      commandNameAndArgsArgv,
+      optionsArgvObject,
+      escapedArgv,
+    } = accumulateArgvObject(...argv);
+    const argsArgv = accumulateCommandStack(rootCommand, commandNameAndArgsArgv);
+
+    if (foundHelp) {
+      throw new UsageError();
+    }
+
+    const lastCommand = LastCommand(rootCommand);
+
+    if (lastCommand._type === BRANCH) {
+      if (argsArgv[0]) {
+        throw new UsageError(`Bad command "${argsArgv[0]}"`);
+      }
+      throw new UsageError();
+    }
+
+    const { value: argsValue, errorMessage: argsErrorMessage } = await callGetValue(
+      lastCommand.args,
+      argsArgv,
+    );
+    if (argsErrorMessage) {
+      throw new UsageError(argsErrorMessage);
+    }
+
+    const {
+      optionsValues,
+      unusedInputNames,
+      missingInputNames,
+      exceptionsRunningGetValue,
+    } = await accumulateOptionsValues(lastCommand, optionsArgvObject);
+    if (exceptionsRunningGetValue.length > 0) {
+      const [inputName, ex] = exceptionsRunningGetValue[0];
+      const message =
+        ex && typeof ex.message === 'string'
+          ? ex.message
+          : 'Problem getting option value';
+      throw new TerseError(`"--${inputName}": ${message}`);
+    }
+
+    if (unusedInputNames.length > 0) {
+      const inputName = unusedInputNames[0];
+      throw new UsageError(`Unknown option name "--${inputName}"`);
+    }
+    if (missingInputNames.length > 0) {
+      const inputName = missingInputNames[0];
+      throw new UsageError(`"--${inputName}" is required`);
+    }
+
+    const { value: escapedValue, errorMessage: escapedErrorMessage } = await callGetValue(
+      lastCommand.escaped,
+      escapedArgv,
+    );
+
+    if (escapedErrorMessage) {
+      throw new UsageError(escapedErrorMessage);
+    }
+
+    const result = await lastCommand.action(argsValue, optionsValues, escapedValue);
+    return result;
+  };
+}

--- a/src/create-cli.ts
+++ b/src/create-cli.ts
@@ -1,96 +1,16 @@
-import { Leaf, Branch, Command } from './types';
-import { getUsage } from './get-usage';
-import { accumulateCommandStack } from './accumulate-command-stack';
-import { accumulateArgvObject } from './accumulate-argv-object';
-import { accumulateOptionsValues } from './accumulate-options-values';
+import { Leaf, Branch } from './types';
 
-import { USAGE, UsageError } from './usage-error';
-import { TERSE, TerseError } from './terse-error';
-import { RED_ERROR, BRANCH } from './constants';
-import { findVersion } from './find-version';
-import { callGetValue } from './call-get-value';
-import { LastCommand } from './last-command';
+import { USAGE } from './usage-error';
+import { TERSE } from './terse-error';
+import { RED_ERROR } from './constants';
+import { createArgvInterface } from './create-argv-interface';
+import { getUsage } from './get-usage';
 
 export function createCli(rootCommand: Branch | Leaf<any, any, any>) {
+  const argvInterface = createArgvInterface(rootCommand);
   return async function cli(...argv: string[]) {
-    if (['-v', '--version'].includes(argv[0])) {
-      if (rootCommand.version) {
-        return rootCommand.version;
-      }
-      const foundVersion = await findVersion();
-      if (foundVersion) {
-        return foundVersion;
-      }
-      throw `${RED_ERROR} Failed to find a CLI "version"`;
-    }
-    const {
-      foundHelp,
-      commandNameAndArgsArgv,
-      optionsArgvObject,
-      escapedArgv,
-    } = accumulateArgvObject(...argv);
-    const argsArgv = accumulateCommandStack(rootCommand, commandNameAndArgsArgv);
-
-    function usage(message?: string) {
-      return getUsage(rootCommand, message);
-    }
-
-    if (foundHelp) {
-      throw usage();
-    }
-
-    const lastCommand = LastCommand(rootCommand);
-
-    if (lastCommand._type === BRANCH) {
-      if (argsArgv[0]) {
-        throw usage(`Bad command "${argsArgv[0]}"`);
-      }
-      throw usage();
-    }
-
     try {
-      const { value: argsValue, errorMessage: argsErrorMessage } = await callGetValue(
-        lastCommand.args,
-        argsArgv,
-      );
-      if (argsErrorMessage) {
-        throw usage(argsErrorMessage);
-      }
-
-      const {
-        optionsValues,
-        unusedInputNames,
-        missingInputNames,
-        exceptionsRunningGetValue,
-      } = await accumulateOptionsValues(lastCommand, optionsArgvObject);
-      if (exceptionsRunningGetValue.length > 0) {
-        const [inputName, ex] = exceptionsRunningGetValue[0];
-        const message =
-          ex && typeof ex.message === 'string'
-            ? ex.message
-            : 'Problem getting option value';
-        throw new TerseError(`"--${inputName}": ${message}`);
-      }
-
-      if (unusedInputNames.length > 0) {
-        const inputName = unusedInputNames[0];
-        throw new UsageError(`Unknown option name "--${inputName}"`);
-      }
-      if (missingInputNames.length > 0) {
-        const inputName = missingInputNames[0];
-        throw new UsageError(`"--${inputName}" is required`);
-      }
-
-      const {
-        value: escapedValue,
-        errorMessage: escapedErrorMessage,
-      } = await callGetValue(lastCommand.escaped, escapedArgv);
-
-      if (escapedErrorMessage) {
-        throw usage(escapedErrorMessage);
-      }
-
-      const result = await lastCommand.action(argsValue, optionsValues, escapedValue);
+      const result = await argvInterface(...argv);
       return result;
     } catch (ex) {
       if (!ex) {
@@ -99,7 +19,7 @@ export function createCli(rootCommand: Branch | Leaf<any, any, any>) {
         }`;
       }
       if (ex.code === USAGE) {
-        throw usage(ex.message);
+        throw getUsage(rootCommand, ex.message);
       }
       if (ex.code === TERSE) {
         throw `${RED_ERROR} ${ex.message || 'No message available'}`;

--- a/src/get-usage.test.ts
+++ b/src/get-usage.test.ts
@@ -1,8 +1,8 @@
 import { getUsage } from './get-usage';
 import { createBranch } from './create-branch';
 import { createStringInput } from './input-factories/create-string-input';
-import { Leaf } from './types';
 import { createLeaf } from './create-leaf';
+import { Command } from './types';
 
 const leaf = createLeaf({
   name: 'echo',
@@ -21,12 +21,19 @@ const root = createBranch({
 
 describe(getUsage.name, () => {
   it('Creates a usage string for a branch', () => {
-    const usageString = getUsage([root]);
+    root.next = undefined;
+    const usageString = getUsage(root);
     expect(usageString).toMatchSnapshot();
   });
 
   it('Creates a usage string for a leaf', () => {
-    const usageString = getUsage([root, leaf as Leaf<any, any, any>]);
+    root.next = leaf;
+    const usageString = getUsage(root);
+    expect(usageString).toMatchSnapshot();
+  });
+
+  it('Creates a usage string for a leaf without a parent branch', () => {
+    const usageString = getUsage(leaf as Command);
     expect(usageString).toMatchSnapshot();
   });
 });

--- a/src/last-command.test.ts
+++ b/src/last-command.test.ts
@@ -1,0 +1,32 @@
+import { createBranch } from './create-branch';
+import { createLeaf } from './create-leaf';
+import { LastCommand } from './last-command';
+
+const leaf = createLeaf({
+  name: 'l',
+  action() {},
+});
+
+const branch = createBranch({
+  name: 'b',
+  subcommands: [leaf],
+});
+
+describe(LastCommand.name, () => {
+  it('returns the passed branch if next is not defined', () => {
+    branch.next = undefined;
+    const lastCommand = LastCommand(branch);
+    expect(lastCommand).toBe(branch);
+  });
+
+  it('returns the passed leaf if a leaf is passed', () => {
+    const lastCommand = LastCommand(leaf);
+    expect(lastCommand).toBe(leaf);
+  });
+
+  it('recursively traverses "next" property', () => {
+    branch.next = leaf;
+    const lastCommand = LastCommand(branch);
+    expect(lastCommand).toBe(leaf);
+  });
+});

--- a/src/last-command.ts
+++ b/src/last-command.ts
@@ -1,0 +1,12 @@
+import { Command } from './types';
+import { LEAF } from './constants';
+
+export function LastCommand(command: Command): Command {
+  if (command._type === LEAF) {
+    return command;
+  }
+  if (!command.next) {
+    return command;
+  }
+  return LastCommand(command.next);
+}

--- a/src/map-command.ts
+++ b/src/map-command.ts
@@ -1,0 +1,15 @@
+import { Command } from './types';
+import { LEAF } from './constants';
+
+export function mapCommand<T>(command: Command, callback: (command: Command) => T) {
+  const result: T[] = [];
+  let current = command;
+  while (true) {
+    result.push(callback(current));
+    if (current._type === LEAF || !current.next) {
+      break;
+    }
+    current = current.next;
+  }
+  return result;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,6 +31,7 @@ export type Branch = {
   hidden?: boolean;
   subcommands: (Branch | Leaf<any, any, any>)[];
   version?: string;
+  next?: Branch | Leaf<any, any, any>;
 };
 
 export type Leaf<T extends AnyInput, U extends AnyNamedInputs, V extends AnyInput> = {
@@ -56,8 +57,3 @@ export type ExcludeInternallyAssigned<T extends { _type: any }> = Pick<
   T,
   Exclude<keyof T, '_type'>
 >;
-
-export type CommandStack = {
-  branches: Branch[];
-  leaf?: Leaf<AnyInput, any, AnyInput>;
-};


### PR DESCRIPTION
Previously the command stack was represented as an array and navigated using iteration. This PR tweaks the internal logic to instead represent the command stack as a linked list by adding a `next` property to the `Branch` type. This facilitates using recursion to traverse the command stack.