### PR TITLE
Support new `runCliAndExit` option `showHidden`

### DIFF
--- a/src/examples/hidden-branch.ts
+++ b/src/examples/hidden-branch.ts
@@ -1,3 +1,4 @@
+import { basename } from 'path';
 import { echoCliLeaf as echoCommand } from './echo';
 import { CliBranch } from '../cli-branch';
 import { runCliAndExit } from '../run-cli-and-exit';
@@ -22,10 +23,15 @@ const hiddenCliBranch = CliBranch({
 
 export const root = CliBranch({
   name: 'cli',
-  description: 'This CLI has a "hidden" command branch called "secret".',
+  description: `
+    This CLI has a "hidden" command branch called "secret".
+    For this CLI, you can see usage for the hidden inputs 
+    by setting SHOW_HIDDEN in your environment, e.g.
+      SHOW_HIDDEN=1 ${basename(process.argv[0])} ${basename(process.argv[1])}
+    `,
   subcommands: [nonHiddenCliBranch, hiddenCliBranch],
 });
 
 if (module === require.main) {
-  runCliAndExit(root);
+  runCliAndExit(root, { showHidden: Boolean(process.env.SHOW_HIDDEN) });
 }

--- a/src/examples/hidden-leaf.ts
+++ b/src/examples/hidden-leaf.ts
@@ -1,3 +1,4 @@
+import { basename } from 'path';
 import { echoCliLeaf as echoCommand } from './echo';
 import { CliLeaf } from '../cli-leaf';
 import { CliBranch } from '../cli-branch';
@@ -14,10 +15,14 @@ export const root = CliBranch({
   name: 'cli',
   description: `
     Non-hidden command "${echoCommand.name}" shows up in this usage documentation.
-    Hidden subcommand "${hiddenEcho.name}" does not appear in the subcommands list.`,
+    Hidden subcommand "${hiddenEcho.name}" does not appear in the subcommands list.
+    For this CLI, you can see usage for the hidden inputs by setting SHOW_HIDDEN
+    in your environment, e.g.
+      SHOW_HIDDEN=1 ${basename(process.argv[0])} ${basename(process.argv[1])}
+    `,
   subcommands: [hiddenEcho, echoCommand],
 });
 
 if (module === require.main) {
-  runCliAndExit(root);
+  runCliAndExit(root, { showHidden: Boolean(process.env.SHOW_HIDDEN) });
 }

--- a/src/examples/hidden-option.ts
+++ b/src/examples/hidden-option.ts
@@ -2,6 +2,7 @@ import { echoCliLeaf as echoCommand } from './echo';
 import { CliLeaf } from '../cli-leaf';
 import { CliFlagInput } from '../cli-flag-input';
 import { runCliAndExit } from '../run-cli-and-exit';
+import { basename } from 'path';
 
 const PIZZA_MESSAGE = `
        _              
@@ -19,9 +20,13 @@ __ __  _ __________ _
 export const root = CliLeaf({
   ...echoCommand,
   description: `
-    This CLI has a hidden option "--pizza". If an option is "hidden", it does not 
-    appear in the command's usage documentation. Hidden options might be "easter eggs" 
-    like in this example or experimental features, for example.`,
+    This CLI has a hidden named input "--pizza". If an option is "hidden", it does not 
+    appear in the command's usage documentation. Hidden inputs might be "easter eggs" 
+    like in this example or experimental features, for example.
+    For this CLI, you can see usage for the hidden inputs by setting SHOW_HIDDEN
+    in your environment, e.g.
+      SHOW_HIDDEN=1 ${basename(process.argv[0])} ${basename(process.argv[1])}
+`,
   namedInputs: { pizza: CliFlagInput({ hidden: true }) },
   action(messages, { pizza }, escaped) {
     if (pizza) {
@@ -32,5 +37,5 @@ export const root = CliLeaf({
 });
 
 if (module === require.main) {
-  runCliAndExit(root);
+  runCliAndExit(root, { showHidden: Boolean(process.env.SHOW_HIDDEN) });
 }

--- a/src/get-path-and-description-of-leaves.ts
+++ b/src/get-path-and-description-of-leaves.ts
@@ -9,9 +9,10 @@ type PathAndDescription = {
 export function getPathAndDescriptionOfLeaves(
   command: Command,
   path: string[],
+  showHidden: boolean,
 ): PathAndDescription[] {
-  if (command.hidden && path.length > 0) {
-    // ^^ conditional on path.length > 0 because we don't want to hide the usage
+  if (!showHidden && command.hidden && path.length > 0) {
+    // conditional on path.length > 0 ^^ because we don't want to hide the usage
     // for the current node, e.g. if a user does `cli hidden-command` it should
     // show the leaves underneath "hidden-command".
     return [];
@@ -27,7 +28,11 @@ export function getPathAndDescriptionOfLeaves(
   const returnValue: PathAndDescription[] = [];
   for (const subcommand of command.subcommands) {
     returnValue.push(
-      ...getPathAndDescriptionOfLeaves(subcommand, [...path, subcommand.name]),
+      ...getPathAndDescriptionOfLeaves(
+        subcommand,
+        [...path, subcommand.name],
+        showHidden,
+      ),
     );
   }
   return returnValue;

--- a/src/run-cli-and-exit.ts
+++ b/src/run-cli-and-exit.ts
@@ -11,6 +11,7 @@ export async function runCliAndExit(
   options: Partial<{
     argv: string[];
     enhancer: CliEnhancer;
+    showHidden: boolean;
     processExit: (code?: number) => any;
     consoleLog: typeof console.log;
     consoleError: typeof console.error;
@@ -19,6 +20,7 @@ export async function runCliAndExit(
   const {
     argv = process.argv.slice(2),
     enhancer,
+    showHidden = false,
     processExit = process.exit,
     consoleLog = console.log,
     consoleError = console.error,
@@ -37,7 +39,9 @@ export async function runCliAndExit(
         `${RED_ERROR} Encountered non-truthy exception "${exception}". Please contact the author of this command-line interface`,
       );
     } else if (exception.code === CLI_USAGE_ERROR) {
-      consoleError(UsageString(rootCommand, exception.message));
+      consoleError(
+        UsageString(rootCommand, { errorMessage: exception.message, showHidden }),
+      );
     } else if (exception.code === CLI_TERSE_ERROR) {
       if (!exception.message) {
         consoleError(exception);


### PR DESCRIPTION
This is a new CLI-global option that would override the "hidden" settings of individual commands/inputs.