### PR TITLE
Added an optional postRun argument in runCliAndExit()

### DIFF
--- a/src/run-cli-and-exit.test.ts
+++ b/src/run-cli-and-exit.test.ts
@@ -1,9 +1,9 @@
-import { CliLeaf } from './cli-leaf';
-import { runCliAndExit } from './run-cli-and-exit';
-import { CliUsageError } from './cli-usage-error';
-import { CliTerseError, CLI_TERSE_ERROR } from './cli-terse-error';
-import { RED_ERROR } from './constants';
-import { CodedError } from '@carnesen/coded-error';
+import { CodedError } from "@carnesen/coded-error";
+import { CliLeaf } from "./cli-leaf";
+import { CliTerseError, CLI_TERSE_ERROR } from "./cli-terse-error";
+import { CliUsageError } from "./cli-usage-error";
+import { RED_ERROR } from "./constants";
+import { runCliAndExit } from "./run-cli-and-exit";
 
 async function runMocked(action: () => any) {
   const result = {
@@ -13,13 +13,13 @@ async function runMocked(action: () => any) {
   };
   await runCliAndExit(
     CliLeaf({
-      name: 'cli',
+      name: "cli",
       action,
     }),
     {
       argv: [],
       ...result,
-    },
+    }
   );
 
   expect(result.processExit.mock.calls.length).toBe(1);
@@ -27,7 +27,7 @@ async function runMocked(action: () => any) {
   const exitCode = result.processExit.mock.calls[0][0];
 
   expect(
-    result.consoleError.mock.calls.length + result.consoleLog.mock.calls.length,
+    result.consoleError.mock.calls.length + result.consoleLog.mock.calls.length
   ).toBeLessThanOrEqual(1);
   let errorMessage: any = undefined;
   let logMessage: any = undefined;
@@ -43,77 +43,77 @@ async function runMocked(action: () => any) {
 }
 
 describe(runCliAndExit.name, () => {
-  it('exits 0 and does not console.log if action succeeds', async () => {
+  it("exits 0 and does not console.log if action succeeds", async () => {
     const { exitCode, errorMessage, logMessage } = await runMocked(() => {});
     expect(exitCode).toBe(0);
     expect(errorMessage).toBe(undefined);
     expect(logMessage).toBe(undefined);
   });
 
-  it('exits 0 and console.logs resolved value if action succeeds', async () => {
-    const { exitCode, errorMessage, logMessage } = await runMocked(() => 'foo');
+  it("exits 0 and console.logs resolved value if action succeeds", async () => {
+    const { exitCode, errorMessage, logMessage } = await runMocked(() => "foo");
     expect(exitCode).toBe(0);
     expect(errorMessage).toBe(undefined);
-    expect(logMessage).toBe('foo');
+    expect(logMessage).toBe("foo");
   });
 
   it('exits 1 and console.errors "non-truthy exception" if action throws a non-truthy exception', async () => {
     const { exitCode, errorMessage, logMessage } = await runMocked(() => {
-      throw '';
+      throw "";
     });
     expect(exitCode).toBe(1);
-    expect(errorMessage).toMatch('non-truthy exception');
+    expect(errorMessage).toMatch("non-truthy exception");
     expect(logMessage).toBe(undefined);
   });
 
-  it('exits 1 and console.errors a usage string if action throws a UsageError', async () => {
+  it("exits 1 and console.errors a usage string if action throws a UsageError", async () => {
     const { exitCode, errorMessage, logMessage } = await runMocked(() => {
       throw new CliUsageError();
     });
     expect(exitCode).toBe(1);
-    expect(errorMessage).toMatch('Usage');
+    expect(errorMessage).toMatch("Usage");
     expect(logMessage).toBe(undefined);
   });
 
-  it('exits 1 and console.errors a red error message if action throws a TerseError', async () => {
+  it("exits 1 and console.errors a red error message if action throws a TerseError", async () => {
     const { exitCode, errorMessage, logMessage } = await runMocked(() => {
-      throw new CliTerseError('foo');
+      throw new CliTerseError("foo");
     });
     expect(exitCode).toBe(1);
     expect(errorMessage).toMatch(RED_ERROR);
-    expect(errorMessage).toMatch('foo');
+    expect(errorMessage).toMatch("foo");
     expect(logMessage).toBe(undefined);
   });
 
-  it('exits 1 and console.errors the full error if action throws a TerseError without a message', async () => {
+  it("exits 1 and console.errors the full error if action throws a TerseError without a message", async () => {
     const { exitCode, errorMessage, logMessage } = await runMocked(() => {
-      throw new CliTerseError('');
+      throw new CliTerseError("");
     });
     expect(exitCode).toBe(1);
-    expect(typeof errorMessage).toBe('object');
+    expect(typeof errorMessage).toBe("object");
     expect(errorMessage.code).toBe(CLI_TERSE_ERROR);
     expect(logMessage).toBe(undefined);
   });
 
-  it('exits with the specified code if the code is a number', async () => {
+  it("exits with the specified code if the code is a number", async () => {
     const { exitCode, errorMessage, logMessage } = await runMocked(() => {
-      throw new CodedError('', 123);
+      throw new CodedError("", 123);
     });
     expect(exitCode).toBe(123);
     expect(errorMessage).toBe(undefined);
     expect(logMessage).toBe(undefined);
   });
 
-  it('exits with the specified code if the code is a number and console.errors the message if there is one', async () => {
+  it("exits with the specified code if the code is a number and console.errors the message if there is one", async () => {
     const { exitCode, errorMessage, logMessage } = await runMocked(() => {
-      throw new CodedError('foo', 123);
+      throw new CodedError("foo", 123);
     });
     expect(exitCode).toBe(123);
-    expect(errorMessage).toBe('foo');
+    expect(errorMessage).toBe("foo");
     expect(logMessage).toBe(undefined);
   });
 
-  it('console.errors any other error thrown and exits 1', async () => {
+  it("console.errors any other error thrown and exits 1", async () => {
     const error = new Error();
     const { exitCode, errorMessage, logMessage } = await runMocked(() => {
       throw error;
@@ -123,13 +123,28 @@ describe(runCliAndExit.name, () => {
     expect(logMessage).toBe(undefined);
   });
 
-  it('uses sensible defaults for all options', async () => {
+  it("uses sensible defaults for all options", async () => {
     runCliAndExit(
       CliLeaf({
-        name: 'cli',
+        name: "cli",
         action() {},
       }),
-      { processExit: jest.fn(), argv: [] },
+      { processExit: jest.fn(), argv: [] }
     );
+  });
+
+  it("passes a postRun argument and assures it's been called", async () => {
+    const postRunMock = jest.fn();
+    await runCliAndExit(
+      CliLeaf({
+        name: "cli",
+        action() {},
+      }),
+      {
+        processExit: jest.fn(),
+        postRun: postRunMock,
+      }
+    );
+    expect(postRunMock).toHaveBeenCalled();
   });
 });

--- a/src/run-cli-and-exit.test.ts
+++ b/src/run-cli-and-exit.test.ts
@@ -1,9 +1,9 @@
-import { CodedError } from "@carnesen/coded-error";
-import { CliLeaf } from "./cli-leaf";
-import { CliTerseError, CLI_TERSE_ERROR } from "./cli-terse-error";
-import { CliUsageError } from "./cli-usage-error";
-import { RED_ERROR } from "./constants";
-import { runCliAndExit } from "./run-cli-and-exit";
+import { CodedError } from '@carnesen/coded-error';
+import { CliLeaf } from './cli-leaf';
+import { CliTerseError, CLI_TERSE_ERROR } from './cli-terse-error';
+import { CliUsageError } from './cli-usage-error';
+import { RED_ERROR } from './constants';
+import { runCliAndExit } from './run-cli-and-exit';
 
 async function runMocked(action: () => any) {
   const result = {
@@ -13,13 +13,13 @@ async function runMocked(action: () => any) {
   };
   await runCliAndExit(
     CliLeaf({
-      name: "cli",
+      name: 'cli',
       action,
     }),
     {
       argv: [],
       ...result,
-    }
+    },
   );
 
   expect(result.processExit.mock.calls.length).toBe(1);
@@ -27,7 +27,7 @@ async function runMocked(action: () => any) {
   const exitCode = result.processExit.mock.calls[0][0];
 
   expect(
-    result.consoleError.mock.calls.length + result.consoleLog.mock.calls.length
+    result.consoleError.mock.calls.length + result.consoleLog.mock.calls.length,
   ).toBeLessThanOrEqual(1);
   let errorMessage: any = undefined;
   let logMessage: any = undefined;
@@ -43,77 +43,77 @@ async function runMocked(action: () => any) {
 }
 
 describe(runCliAndExit.name, () => {
-  it("exits 0 and does not console.log if action succeeds", async () => {
+  it('exits 0 and does not console.log if action succeeds', async () => {
     const { exitCode, errorMessage, logMessage } = await runMocked(() => {});
     expect(exitCode).toBe(0);
     expect(errorMessage).toBe(undefined);
     expect(logMessage).toBe(undefined);
   });
 
-  it("exits 0 and console.logs resolved value if action succeeds", async () => {
-    const { exitCode, errorMessage, logMessage } = await runMocked(() => "foo");
+  it('exits 0 and console.logs resolved value if action succeeds', async () => {
+    const { exitCode, errorMessage, logMessage } = await runMocked(() => 'foo');
     expect(exitCode).toBe(0);
     expect(errorMessage).toBe(undefined);
-    expect(logMessage).toBe("foo");
+    expect(logMessage).toBe('foo');
   });
 
   it('exits 1 and console.errors "non-truthy exception" if action throws a non-truthy exception', async () => {
     const { exitCode, errorMessage, logMessage } = await runMocked(() => {
-      throw "";
+      throw '';
     });
     expect(exitCode).toBe(1);
-    expect(errorMessage).toMatch("non-truthy exception");
+    expect(errorMessage).toMatch('non-truthy exception');
     expect(logMessage).toBe(undefined);
   });
 
-  it("exits 1 and console.errors a usage string if action throws a UsageError", async () => {
+  it('exits 1 and console.errors a usage string if action throws a UsageError', async () => {
     const { exitCode, errorMessage, logMessage } = await runMocked(() => {
       throw new CliUsageError();
     });
     expect(exitCode).toBe(1);
-    expect(errorMessage).toMatch("Usage");
+    expect(errorMessage).toMatch('Usage');
     expect(logMessage).toBe(undefined);
   });
 
-  it("exits 1 and console.errors a red error message if action throws a TerseError", async () => {
+  it('exits 1 and console.errors a red error message if action throws a TerseError', async () => {
     const { exitCode, errorMessage, logMessage } = await runMocked(() => {
-      throw new CliTerseError("foo");
+      throw new CliTerseError('foo');
     });
     expect(exitCode).toBe(1);
     expect(errorMessage).toMatch(RED_ERROR);
-    expect(errorMessage).toMatch("foo");
+    expect(errorMessage).toMatch('foo');
     expect(logMessage).toBe(undefined);
   });
 
-  it("exits 1 and console.errors the full error if action throws a TerseError without a message", async () => {
+  it('exits 1 and console.errors the full error if action throws a TerseError without a message', async () => {
     const { exitCode, errorMessage, logMessage } = await runMocked(() => {
-      throw new CliTerseError("");
+      throw new CliTerseError('');
     });
     expect(exitCode).toBe(1);
-    expect(typeof errorMessage).toBe("object");
+    expect(typeof errorMessage).toBe('object');
     expect(errorMessage.code).toBe(CLI_TERSE_ERROR);
     expect(logMessage).toBe(undefined);
   });
 
-  it("exits with the specified code if the code is a number", async () => {
+  it('exits with the specified code if the code is a number', async () => {
     const { exitCode, errorMessage, logMessage } = await runMocked(() => {
-      throw new CodedError("", 123);
+      throw new CodedError('', 123);
     });
     expect(exitCode).toBe(123);
     expect(errorMessage).toBe(undefined);
     expect(logMessage).toBe(undefined);
   });
 
-  it("exits with the specified code if the code is a number and console.errors the message if there is one", async () => {
+  it('exits with the specified code if the code is a number and console.errors the message if there is one', async () => {
     const { exitCode, errorMessage, logMessage } = await runMocked(() => {
-      throw new CodedError("foo", 123);
+      throw new CodedError('foo', 123);
     });
     expect(exitCode).toBe(123);
-    expect(errorMessage).toBe("foo");
+    expect(errorMessage).toBe('foo');
     expect(logMessage).toBe(undefined);
   });
 
-  it("console.errors any other error thrown and exits 1", async () => {
+  it('console.errors any other error thrown and exits 1', async () => {
     const error = new Error();
     const { exitCode, errorMessage, logMessage } = await runMocked(() => {
       throw error;
@@ -123,13 +123,13 @@ describe(runCliAndExit.name, () => {
     expect(logMessage).toBe(undefined);
   });
 
-  it("uses sensible defaults for all options", async () => {
+  it('uses sensible defaults for all options', async () => {
     runCliAndExit(
       CliLeaf({
-        name: "cli",
+        name: 'cli',
         action() {},
       }),
-      { processExit: jest.fn(), argv: [] }
+      { processExit: jest.fn(), argv: [] },
     );
   });
 
@@ -137,13 +137,13 @@ describe(runCliAndExit.name, () => {
     const postRunMock = jest.fn();
     await runCliAndExit(
       CliLeaf({
-        name: "cli",
+        name: 'cli',
         action() {},
       }),
       {
         processExit: jest.fn(),
         postRun: postRunMock,
-      }
+      },
     );
     expect(postRunMock).toHaveBeenCalled();
   });

--- a/src/run-cli-and-exit.ts
+++ b/src/run-cli-and-exit.ts
@@ -1,9 +1,9 @@
-import { CliLeaf, CliBranch } from './types';
+import { CliBranch, CliLeaf } from './types';
 
-import { CLI_USAGE_ERROR } from './cli-usage-error';
-import { CLI_TERSE_ERROR } from './cli-terse-error';
-import { RED_ERROR } from './constants';
 import { CliArgvInterface, CliEnhancer } from './cli-argv-interface';
+import { CLI_TERSE_ERROR } from './cli-terse-error';
+import { CLI_USAGE_ERROR } from './cli-usage-error';
+import { RED_ERROR } from './constants';
 import { UsageString } from './usage-string';
 
 function isErrnoException(error: any): error is NodeJS.ErrnoException {
@@ -21,6 +21,7 @@ export async function runCliAndExit(
     processExit: (code?: number) => any;
     consoleLog: typeof console.log;
     consoleError: typeof console.error;
+    postRun?: () => void;
   }> = {},
 ) {
   const {
@@ -29,6 +30,7 @@ export async function runCliAndExit(
     processExit = process.exit,
     consoleLog = console.log,
     consoleError = console.error,
+    postRun,
   } = options;
   const argvInterface = CliArgvInterface(rootCommand, { enhancer });
   let exitCode = 0;
@@ -60,6 +62,7 @@ export async function runCliAndExit(
       consoleError(exception);
     }
   } finally {
+    postRun?.();
     processExit(exitCode);
   }
 }

--- a/src/run-cli-and-exit.ts
+++ b/src/run-cli-and-exit.ts
@@ -21,7 +21,7 @@ export async function runCliAndExit(
     processExit: (code?: number) => any;
     consoleLog: typeof console.log;
     consoleError: typeof console.error;
-    postRun?: () => void;
+    postRun?: () => Promise<void>;
   }> = {},
 ) {
   const {
@@ -62,7 +62,7 @@ export async function runCliAndExit(
       consoleError(exception);
     }
   } finally {
-    postRun?.();
+    await postRun?.();
     processExit(exitCode);
   }
 }


### PR DESCRIPTION
Added an optional postRun argument in runCliAndExit() function, that is invoked right before processExit().

This allows for running any command at the end of the Cli execution, for example used to display an update message, if one is available, or a custom message in the future.